### PR TITLE
[VA] #20: Implementar código fonte do va-status (Status Page)

### DIFF
--- a/va-notes/issue-20.md
+++ b/va-notes/issue-20.md
@@ -1,0 +1,15 @@
+# VA Agent Output — Issue #20
+
+> JSON parsing failed: expected value at line 1 column 1
+
+## Raw LLM Output
+
+```json
+{
+  "commit_message": "feat: Implement va-status (Status Page) service",
+  "description": "This commit implements the `va-status` service, a status page application built with Rust (Axum) and PostgreSQL (SQLx).\n\nKey features include:\n- **API Endpoints**: `GET /status` for overall status, `POST /services` to register new services, and `PATCH /services/:id/status` to update service status and manage incidents.\n- **Database Schema**: PostgreSQL tables `services` and `incidents` with proper RLS, `tenant_id`, `BIGSERIAL` primary keys, `TIMESTAMPTZ` timestamps, and `updated_at` triggers.\n- **Incident Management**: Automatic incident creation/resolution based on service status changes.\n- **Webhook Support**: Placeholder for webhook notifications on status changes.\n- **Error Handling**: Custom error types with `thiserror` and `anyhow`.\n- **Configuration**: Environment variable loading via `dotenvy`.\n\nThis addresses Issue #20 by providing the core functionality for the `va-status` application.",
+  "files": [
+    {
+      "path": "Cargo.toml",
+      "action": "create",
+      "content": "[workspace]\nmembers = [\n    \"crates/va-core\",\n    \"crates/va-paste\",\n    \"crates/va-paste-server\",\n    \"crates/va-status-server


### PR DESCRIPTION
## VA Agent

Analysis result — no code changes parsed

**Files changed:**
- `va-notes/issue-20.md`

**Model**: gemini-3.1-pro-preview | **Department**: dev | **Skill**: rust_backend

---
> ✅ **Before merging**: Wait for CI (`cargo check + cargo test`) to pass. Review all modified files for completeness — do not merge if any file looks like a stub.

*Generated by VertexAgents v9.0 Daemon*

> ⚠️ JSON parse failed — this PR contains the raw LLM output as a note file.